### PR TITLE
consolidate raid/egg levels source

### DIFF
--- a/src/lib/poracleMessage/commands/egg.js
+++ b/src/lib/poracleMessage/commands/egg.js
@@ -1,5 +1,6 @@
 const helpCommand = require('./help')
 const trackedCommand = require('./tracked')
+const { raidLevels } = require('../../../util/util.json')
 
 exports.run = async (client, msg, args, options) => {
 	const logReference = Math.random().toString().slice(2, 11)
@@ -57,7 +58,7 @@ exports.run = async (client, msg, args, options) => {
 			else if (element === 'valor' || element === 'red') team = 2
 			else if (element === 'mystic' || element === 'blue') team = 1
 			else if (element === 'harmony' || element === 'gray') team = 0
-			else if (element === 'everything') [1, 3, 4, 5, 6, 7, 8, 9].forEach((x) => levelSet.add(x))
+			else if (element === 'everything') Object.keys(raidLevels).forEach((x) => levelSet.add(+x))
 			else if (element === 'clean') clean = true
 		})
 		if (client.config.tracking.defaultDistance !== 0 && distance === 0 && !msg.isFromAdmin) distance = client.config.tracking.defaultDistance

--- a/src/lib/poracleMessage/commands/raid.js
+++ b/src/lib/poracleMessage/commands/raid.js
@@ -1,5 +1,6 @@
 const helpCommand = require('./help')
 const trackedCommand = require('./tracked')
+const { raidLevels } = require('../../../util/util.json')
 
 exports.run = async (client, msg, args, options) => {
 	const logReference = Math.random().toString().slice(2, 11)
@@ -102,7 +103,7 @@ exports.run = async (client, msg, args, options) => {
 			else if (element === 'valor' || element === 'red') team = 2
 			else if (element === 'mystic' || element === 'blue') team = 1
 			else if (element === 'harmony' || element === 'gray') team = 0
-			else if (element === 'everything') [1, 3, 4, 5, 6, 7, 8, 9].forEach((x) => levelSet.add(x))
+			else if (element === 'everything') Object.keys(raidLevels).forEach((x) => levelSet.add(+x))
 			else if (element === 'clean') clean = true
 		}
 		if (client.config.tracking.defaultDistance !== 0 && distance === 0 && !msg.isFromAdmin) distance = client.config.tracking.defaultDistance

--- a/src/routes/apiTrackingEgg.js
+++ b/src/routes/apiTrackingEgg.js
@@ -1,6 +1,7 @@
 const { diff } = require('deep-object-diff')
 
 const trackedCommand = require('../lib/poracleMessage/commands/tracked')
+const { raidLevels } = require('../util/util.json')
 
 module.exports = async (fastify, options, next) => {
 	fastify.get('/api/tracking/egg/:id', options, async (req) => {
@@ -85,7 +86,7 @@ module.exports = async (fastify, options, next) => {
 
 		const insert = insertReq.map((row) => {
 			const level = +row.level
-			if (row.level === undefined || level < 1 || (level > 10 && level !== 90)) {
+			if (row.level === undefined || level < 1 || (level > Math.max(...Object.keys(raidLevels).map((k) => +k)) && level !== 90)) {
 				throw new Error('Invalid level')
 			}
 			return {

--- a/src/routes/apiTrackingRaid.js
+++ b/src/routes/apiTrackingRaid.js
@@ -1,6 +1,7 @@
 const { diff } = require('deep-object-diff')
 
 const trackedCommand = require('../lib/poracleMessage/commands/tracked')
+const { raidLevels } = require('../util/util.json')
 
 module.exports = async (fastify, options, next) => {
 	fastify.get('/api/tracking/raid/:id', options, async (req) => {
@@ -86,7 +87,7 @@ module.exports = async (fastify, options, next) => {
 			let level = 9000
 			if (row.pokemon_id === 9000) {
 				level = +row.level
-				if (row.level === undefined || level < 1 || (level > 10 && level !== 90)) {
+				if (row.level === undefined || level < 1 || (level > Math.max(...Object.keys(raidLevels).map((k) => +k)) && level !== 90)) {
 					throw new Error('Invalid level (must be specified if no pokemon_id')
 				}
 			}

--- a/src/util/util.json
+++ b/src/util/util.json
@@ -877,8 +877,11 @@
 		"8": "Ultra Beast",
 		"9": "Elite",
 		"10": "Primal",
-		"11": "Unknown",
-		"12": "Unknown"
+		"11": "Level 1 Shadow",
+		"12": "Level 2 Shadow",
+		"13": "Level 3 Shadow",
+		"14": "Level 4 Shadow",
+		"15": "Shadow Legendary"
 	},
 	"emojis": {
 		"lure-normal": "\ud83d\udccd",


### PR DESCRIPTION
- Add raid levels 11-15 to `util.json`
- `everything` for `raid` and `egg` commands will now read from `util.json`
- Max levels accepted by the api will be calculated from `util.json`

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `npm run lint`. Fix anything it is unhappy about -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.